### PR TITLE
Add square style to zoom buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,8 +44,8 @@
           <div id="mermaid-preview"></div>
           <pre class="error-overlay"></pre>
           <div class="floating-controls">
-            <button id="zoom-in-btn" class="button" title="Zoom In">+</button>
-            <button id="zoom-out-btn" class="button" title="Zoom Out">-</button>
+            <button id="zoom-in-btn" class="button zoom-button" title="Zoom In">+</button>
+            <button id="zoom-out-btn" class="button zoom-button" title="Zoom Out">-</button>
             <button id="export-btn" class="button" title="Export as SVG">SVG</button>
             <button id="export-png-btn" class="button" title="Export as PNG">PNG</button>
           </div>

--- a/src/style.css
+++ b/src/style.css
@@ -98,6 +98,14 @@ body {
         /* Base minimum width on the height (font size + padding) */
 }
 
+/* Ensure zoom buttons are perfect squares */
+.zoom-button {
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    font-size: 1rem;
+}
+
 .button:hover {
     background: #f0f0f0;
 }


### PR DESCRIPTION
## Summary
- ensure zoom controls are square by styling them with `.zoom-button`
- apply the new class to zoom buttons in the HTML

## Testing
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_685113b6e3a8832badf929b9a3bf698a