### PR TITLE
Fix TypeScript error: use hideEditorPane() method

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -92,7 +92,9 @@ class MermaidEditor {
     const urlParams = new URLSearchParams(window.location.search);
     const hideEditor = urlParams.has("hideEditor");
 
-    if (!hideEditor) {
+    if (hideEditor) {
+      this.hideEditorPane();
+    } else {
       this.showEditorPane();
     }
 


### PR DESCRIPTION
### Summary
This PR fixes the Cloudflare Pages build failure caused by a TypeScript compilation error.

### Changes
- Updated `handleEditorVisibility()` method in src/main.ts to properly use the `hideEditorPane()` method
- Fixed TypeScript error: `error TS6133: 'hideEditorPane' is declared but its value is never read`

### Root Cause
The `hideEditorPane()` method was declared but never called, causing TypeScript compilation to fail during the Cloudflare Pages build process.

### Impact
The `?hideEditor` URL parameter now properly hides the editor pane as intended.

Closes #5

---

Generated with [Claude Code](https://claude.ai/code)